### PR TITLE
Add return type declaration support for monolog

### DIFF
--- a/src/Coralogix/Handlers/CoralogixMonologHandler.php
+++ b/src/Coralogix/Handlers/CoralogixMonologHandler.php
@@ -82,7 +82,7 @@ final class CoralogixMonologHandler extends AbstractProcessingHandler
      * @param array $record log record
      * @access protected
      */
-    protected function write(array $record)
+    protected function write(array $record): void
     {
         $this->logger_manager->add_logline(
             $record["message"],


### PR DESCRIPTION
For integration of sdk in laravel this change is mandatory. `AbstractProcessingHandler` has return type declaration implemented in its abstract method. we can safely merge this because its already mentioned in docs that this package is only compatible with php > 7.0.